### PR TITLE
Fix "tox -l" use by overriding the default envlist

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ matrix:
   fast_finish: true
 
 install:
-  - C:\Python37\python -m pip install -U six setuptools wheel
+  - C:\Python37\python -m pip install -U pip virtualenv setuptools wheel six
   - C:\Python37\python -m pip install -U tox
 
 test_script:

--- a/src/tox_factor/hooks.py
+++ b/src/tox_factor/hooks.py
@@ -63,3 +63,8 @@ def tox_configure(config):
     if config.option.factor:
         factors = normalize_factors(config.option.factor)
         config.envlist = get_envlist(config._cfg, factors)
+
+        # TEMP: setting config.envlist_default fixes tox -l usage (and by
+        # extension, the test suite). The longterm fix is to add a new option
+        # to tox (e.g., tox -ls) that lists the selected envs (config.envlist).
+        config.envlist_default = config.envlist


### PR DESCRIPTION
Fixes #5. 