### PR TITLE
Update for isort 5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,15 +16,7 @@ max_complexity = 10
 
 
 [isort]
-skip = .tox
-atomic = true
-line_length = 90
-multi_line_output = 4
-include_trailing_comma = true
-known_standard_library = mock
-known_third_party = tox,py
-known_first_party = tox_factor
-
+profile = black
 
 [metadata]
 name = tox-factor

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,5 +1,6 @@
-import mock
 from unittest import TestCase
+
+import mock
 
 from tox_factor.compat import TOX_PARALLEL_ENV
 from tox_factor.hooks import normalize_factors, tox_configure

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = python -m unittest {posargs:discover}
 usedevelop = False
 
 [testenv:isort]
-commands = isort --check-only --recursive src {posargs:--diff}
+commands = isort --check --diff src tests
 deps =
     isort
 


### PR DESCRIPTION
* Use 'profile = black' rather than handcrafted configuration: https://pycqa.github.io/isort/docs/configuration/profiles/
* Remove depreacted `--recursive` flag, which is now the default